### PR TITLE
Add recency requirement to verification steps

### DIFF
--- a/docs/docs_source/scenarios/proofkeys.rst
+++ b/docs/docs_source/scenarios/proofkeys.rst
@@ -17,6 +17,7 @@ request. To verify that a request came from Office Online, you must:
 * Create the expected value of the proof headers.
 * Use the public key provided in WOPI discovery to decrypt the proof provided in the **X-WOPI-Proof** header.
 * Compare the expected proof to the decrypted proof. If they match, the request originated from Office Online.
+* Ensure that the **X-WOPI-TimeStamp** header is no more than 20 minutes old.
 
 Constructing the expected proof
 -------------------------------


### PR DESCRIPTION
The reason the X-WOPI_TimeStamp header is included in the signed payload
is to ensure that the signature is not stale.  The WOPI Host should
reject the request if the timestamp is older than 20 minutes.  At least that was the case when it was first implemented...