### PR TITLE
Clean up PutRelativeFile docs.

### DIFF
--- a/docs/docs_source/concepts.rst
+++ b/docs/docs_source/concepts.rst
@@ -19,12 +19,14 @@ understanding the requirements for Office Online integration.
         A file ID must:
 
         * Represent a single Office document.
-        * Be a URL-safe string because IDs are passed in URLs, principally via the WOPIsrc parameter.
+        * Be a URL-safe string because IDs are passed in URLs, principally via the :term:`WOPISrc` parameter.
         * Remain the same when the file is moved, renamed, or edited.
         * In the case of shared documents, the ID for a given file must be the same for every user that accesses the
           file.
 
-        See :ref:`Action URLs` for more information about how the file ID should be passed to Office Online.
+        Note that the file ID is not provided to Office Online directly. Rather, it is passed as part of the
+        :term:`WOPISrc` value. See :ref:`Action URLs` and :ref:`WOPISrc` for more information about how the file ID
+        should be passed to Office Online.
 
     Access token
         An access token is a string used by the host to determine the identity and permissions of the issuer of a
@@ -80,3 +82,15 @@ understanding the requirements for Office Online integration.
 
         The specific conditions for each response are covered in the documentation for each lock-related WOPI
         operation.
+
+    WOPISrc
+        The WOPISrc (*WOPI Source*) is the URL used to execute WOPI operations on a file. It is a combination of the
+        :ref:`Files endpoint` URL for the host along with a particular :term:`file ID`. The WOPISrc does *not*
+        include an :term:`access token`. When invoking Office Online, hosts provide the WOPISrc instead of just
+        the :term:`file ID`.
+
+        The WOPISrc is needed beyond just a file ID so that Office Online can know what URL to call back to when
+        executing WOPI operations on a file. From an Office Online perspective, the WOPISrc and a :term:`file ID`
+        are synonymous, since Office Online always works with the WOPISrc itself, not the raw :term:`file ID`.
+
+        See :ref:`WOPISrc` for more details on how the WOPISrc is constructed and passed to Office Online.

--- a/docs/docs_source/contributing/build_docs.rst
+++ b/docs/docs_source/contributing/build_docs.rst
@@ -8,6 +8,7 @@ Building this documentation locally
 
     exe
 
+
 If you want to build this documentation locally, use the following steps:
 
 #.  Clone the repository.

--- a/docs/docs_source/discovery.rst
+++ b/docs/docs_source/discovery.rst
@@ -294,6 +294,8 @@ Placeholder values
         ``1`` denotes a light-colored theme and ``2`` denotes a darker colored theme.
 
 
+..  _WOPISrc:
+
 Appending a WOPISrc value
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -304,12 +306,6 @@ instantiate an Office Online application.
 The ``WOPISrc`` parameter tells Office Online the URL of the host's WOPI :ref:`Files endpoint`. In other words,
 it is a URL of the form ``http://server/<...>/wopi*/files/(id)``, where ``id`` is the :term:`file id` of the file. The
 ``WOPISrc`` parameter value must be encoded to a URL-safe string, then the parameter is appended to the action URL.
-
-..  tip::
-
-    It may be useful to think of the ``WOPISrc`` parameter as the :ref:`CheckFileInfo` URL for the file. The
-    only difference between the ``WOPISrc`` parameter and the :ref:`CheckFileInfo` URL is that the ``WOPISrc``
-    parameter does not include an :term:`access token`.
 
 
 Additional notes

--- a/docs/docs_source/postmessage.rst
+++ b/docs/docs_source/postmessage.rst
@@ -10,6 +10,7 @@ Integrating with Office Online by using PostMessage
 
     msg
 
+
 You can integrate your UI into Office Online applications. This way, you can use your UI for actions on Office
 documents, such as sharing.
 

--- a/docs/docs_source/wopi/files/PutRelativeFile.rst
+++ b/docs/docs_source/wopi/files/PutRelativeFile.rst
@@ -6,6 +6,11 @@
 PutRelativeFile
 ===============
 
+..  spelling::
+
+    Url
+
+
 ..  default-domain:: http
 
 ..  post:: /wopi*/files/(id)
@@ -54,34 +59,43 @@ PutRelativeFile
     :code 500: Server error
     :code 501: Unsupported
 
+Response
+--------
+
+The response to a PutRelativeFile call is JSON (as specified in :rfc:`4627`) containing a number of parameters, some of
+which are optional.
+
+All optional values default to the following values based on their type:
+
+=======  ================
+Type     Default value
+=======  ================
+Boolean  ``false``
+String   The empty string
+=======  ================
+
+
 Required response properties
 ----------------------------
 
-..  default-domain:: js
-
 The following properties must be present in all PutRelativeFile responses:
 
-..  data:: Name
-    :noindex:
+Name
+    The **string** name of the newly created file without a path. **This is a required value in all PutRelativeFile
+    responses.**
 
-    The **string** name of the newly created file without a path.
-    **This is a required value in all PutRelativeFile responses.**
-
-..  data:: Url
-    :noindex:
-
-    The **string** URI to the :ref:`CheckFileInfo` URI of the newly created file on the host.
+Url
+    A **string** URI of the form ``http://server/<...>/wopi*/files/(id)?access_token=(access token)``, of the newly
+    created file on the host. This URL is the :ref:`WOPISrc` for the file with an :term:`access token` appended. Or,
+    stated differently, it is the URL to the host's :ref:`Files endpoint` for the file, along with an
+    :term:`access token`. A :http:get: request to this URL will invoke the :ref:`CheckFileInfo` operation.
     **This is a required value in all PutRelativeFile responses.**
 
 Optional response properties
 ----------------------------
 
-..  data:: HostViewUrl
-    :noindex:
+HostViewUrl
+    The :term:`HostViewUrl`, as a **string**, for the newly created file.
 
-    The :data:`HostViewUrl` for the newly created file.
-
-..  data:: HostEditUrl
-    :noindex:
-
-    The :data:`HostEditUrl` for the newly created file.
+HostEditUrl
+    The :term:`HostEditUrl`, as a **string**, for the newly created file.


### PR DESCRIPTION
Use consistent doc formatting for responses, and clarify that the
response is JSON.

Fixes #65.