### PR TITLE
Change size in CheckFileInfo from an int to a long

### DIFF
--- a/docs/docs_source/wopi/files/CheckFileInfo.rst
+++ b/docs/docs_source/wopi/files/CheckFileInfo.rst
@@ -55,7 +55,7 @@ The following properties must be present in all CheckFileInfo responses:
             :ref:`User identity properties`.
 
     Size
-        The size of the file in bytes, expressed as an **int**.
+        The size of the file in bytes, expressed as a **long**, a 64 bit signed integer.
         **This is a required value in all CheckFileInfo responses.**
 
     Version


### PR DESCRIPTION
Will wait to merge this into the documentation until the change goes out the door with the Q3 release.