### PR TITLE
Additional native auth documentation (session context, url params)

### DIFF
--- a/docs/native/src/identity/oauthparams.rst
+++ b/docs/native/src/identity/oauthparams.rst
@@ -1,3 +1,42 @@
 
-|stub-icon| |Office iOS| specific URL parameters for OAuth2 sign-in page
-========================================================================
+|Office iOS| OAuth2 sign-in URL parameters
+==========================================
+
+The HTTPS request to load the OAuth2 Authorization page (:rfc:`6749#section-3.1`) includes standard OAuth2 parameters 
+such as ``client_id``, ``redirect_uri``, etc. but may also include Office-specific parameters, documented here.
+
+    ..  important:: Early releases of |Office iOS| may not include some or all of these URL parameters, so callers should fall back to reasonable defaults.
+
+Culture
+-------
+
+The request includes the :http:header:`Accept-Language` header. The value of this header is determined by the iOS 
+language settings.  In addition, the following URL parameter is appended to the request URL::
+
+    rs=Culture
+
+Culture contains the UI culture of the Office interface, e.g. ``en-US``.
+
+Build
+-----
+
+The following URL parameter is appended to the request URL::
+
+    Build=#
+
+"#" will be a string showing the build of the Office application making the request.
+
+Platform
+--------
+
+The Platform URL parameter communicates which platform the app is running on.
+
+	Platform=iOS
+
+Example
+-------
+
+Here's a request to the sign-in endpoint showing all parameters in use::
+
+    https://contoso.com/api/oauth2/authorize?&rs=en-US&Build=1.21.417&Platform=iOS&client_id=abcdefg&redirect_uri=https%3A%2F%2Flocalhost&response_type=code
+

--- a/docs/native/src/identity/sessioncontext.rst
+++ b/docs/native/src/identity/sessioncontext.rst
@@ -1,3 +1,36 @@
 
-|stub-icon| Session Context
-===========================
+Optional Session Context String
+===============================
+
+..  spelling::
+
+    abcdefg
+    https
+    localhost
+
+A Session Context String may be returned from the authentication process. |Office iOS| will pass this string, in an HTTP header, in calls to the 
+token endpoint URL (:rfc:`6749#section-3.2`) and authenticated calls to the bootstrapper (:ref:`wopirest:GetNewAccessToken`, :ref:`wopirest:shortcuts`).
+
+The Session Context String is optional, and for the use of the storage provider. A possible scenario would be to include a hint about 
+a "tenant" so endpoints can know where they need to fetch and/or validate tokens.
+
+Returning a Session Context string is done via an ``sc=`` URL parameter appended to the value of the
+:http:header:`Location` header from the :http:statuscode:`302` response at the end of the sign-in flow.
+
+    ..  important:: The contents of the ``sc=`` parameter must be URL encoded.
+
+For example, to return the following information:
+
+* Redirection URI is \https://localhost
+* Authorization code (:rfc:`6749#section-4.1.2`) is "abcdefg"
+* Session Context String is "hello:World"
+ 
+The :http:header:`Location` header in the :http:statuscode:`302` response would be::
+
+    Location: https://localhost/?code=abcdefg&sc=hello%3AWorld
+
+If present, the session context string will be included as an HTTP header when calls are made to 
+the token exchange endpoint, and OAuth2 authenticated calls to the bootstrapper 
+(:ref:`wopirest:GetNewAccessToken`, :ref:`wopirest:shortcuts`) as follows::
+
+    X-WOPI-SessionContext: hello:World

--- a/docs/native/src/identity/specifytokenissuance.rst
+++ b/docs/native/src/identity/specifytokenissuance.rst
@@ -32,9 +32,9 @@ For example, to return the following information:
 * Authorization code (:rfc:`6749#section-4.1.2`) is "abcdefg"
 * Token endpoint URL is \https://contoso.com/api/token/?extra=stuff
 
-The :http:header:`Location` header in the :http:statuscode:`302` response would be:
+The :http:header:`Location` header in the :http:statuscode:`302` response would be::
 
-Location: \https://localhost?code=abcdefg&tk=https%3A%2F%2Fcontoso.com%2Fapi%2Ftoken%2F%3Fextra%3Dstuff
+    Location: https://localhost?code=abcdefg&tk=https%3A%2F%2Fcontoso.com%2Fapi%2Ftoken%2F%3Fextra%3Dstuff
 
 As a result, all calls to the token endpoint for obtaining access token via authentication-code exchange, or refresh
 flows using the refresh token, will hit this URL instead of the one initially returned as described at :ref:`ClientBootstrapper`.


### PR DESCRIPTION
Filled out page on custom session context, and additional URL
parameters, and made example in token issuance page use same style as
other pages.