### PR TITLE
Update GetRootContainer (bootstrapper).json

### DIFF
--- a/docs/rest/src/_fragments/responses/GetRootContainer (bootstrapper).json
+++ b/docs/rest/src/_fragments/responses/GetRootContainer (bootstrapper).json
@@ -12,8 +12,8 @@
     },
     "ContainerInfo" : {
       "Name" : "Container Name",
-      "HostUrl" : "",
-      "SharingUrl" : "",
+      "HostUrl" : "http://contoso/324332",
+      "SharingUrl" : "http://contoso/323432/efewos",
       "UserCanCreateChildContainer" : false,
       "UserCanCreateChildFile" : false,
       "UserCanDelete" : false,


### PR DESCRIPTION
making the hosting url and sharing url non-empty string. 
The previous empty string was making partners think optional values should be "" while they should just be omitted. Adding real values to make it more clear.