### PR TITLE
Adding a Note to use Test/Environment Discovery URL

### DIFF
--- a/docs/online/src/build_test_ship/validator.rst
+++ b/docs/online/src/build_test_ship/validator.rst
@@ -17,6 +17,11 @@ The WOPI Validation application is an Office Online application similar to Word 
 It uses the ``.wopitest`` file extension. The WOPI Validation application is included in the :ref:`discovery`
 XML just like all other Office Online applications.
 
+..  important::
+
+	The hosts should use the ``Test/DogFood`` Environment's URL from :ref:`discovery URLs` to ensure that they 
+	are running the latest version of the :ref:`validator`.
+
 ..  code-block:: xml
 
     <app name="WopiTest" checkLicense="true">


### PR DESCRIPTION
Include an important note to run the Test/Environment Discovery URL to run the latest version of the WOPI validation application.