### PR TITLE
Master

### DIFF
--- a/docs/native/src/issues/invalidcharacters.rst
+++ b/docs/native/src/issues/invalidcharacters.rst
@@ -1,0 +1,9 @@
+
+|Office iOS| will fail to load files with invalid characters in the file name, folder names or user ID. 
+=======================================================================================================
+
+If a file name, folder name or user ID contains the following characters, the file will not open properly in |Office iOS|:
+
+\/:*?"<>|#{}^[]`%
+
+To work around this issue, please replace these characters with "-" when sending the file to Office. 

--- a/docs/native/src/issues/invalidcharacters.rst
+++ b/docs/native/src/issues/invalidcharacters.rst
@@ -4,6 +4,6 @@
 
 If a file name, folder name or user ID contains the following characters, the file will not open properly in |Office iOS|:
 
-\/:*?"<>|#{}^[]`%
+\/:*?"<>|#{}^[]`%_
 
 To work around this issue, please replace these characters with "-" when sending the file to Office. 

--- a/docs/native/src/reference/knownissues.rst
+++ b/docs/native/src/reference/knownissues.rst
@@ -1,3 +1,9 @@
 
-|stub-icon| Known issues
-========================
+Known issues
+============
+
+..  toctree::
+    :maxdepth: 1
+    :glob:
+
+    /issues/*


### PR DESCRIPTION
Updated the known issue section with the requirement that files, folder names or user ID's cannot contain the following characters: \/:*?"<>|#{}^[]`%_