### PR TITLE
Start adding docs for workflow.

### DIFF
--- a/docs/_shared/spelling_wordlist.txt
+++ b/docs/_shared/spelling_wordlist.txt
@@ -51,4 +51,5 @@ wdPreviousSession
 webpage
 Wiki
 workflow
+workflows
 WOPI

--- a/docs/online/src/index.rst
+++ b/docs/online/src/index.rst
@@ -165,6 +165,7 @@ Finally, **if you are looking for more details about the process for shipping yo
     /scenarios/business
     /scenarios/conversion
     /scenarios/proofkeys
+    /scenarios/workflow
 
 
 ..  toctree::

--- a/docs/online/src/scenarios/customization.rst
+++ b/docs/online/src/scenarios/customization.rst
@@ -165,6 +165,22 @@ settings prohibit it, etc.), |wac| UI that triggers a PostMessage will be hidden
             scheme and host name. If you are serving your pages on a non-standard port, you must include the port as
             well. The literal string ``*``, while supported in the PostMessage protocol, is not allowed by |wac|.
 
+    WorkflowPostMessage
+        |prerelease|
+
+        A **Boolean** value that, when set to ``true``, indicates the host expects to receive the
+        :js:data:`UI_Workflow` PostMessage when the *Workflow* UI in |wac| is activated.
+
+        Hosts can also use the :term:`WorkflowUrl` property to indicate that a new browser window should be opened
+        when the *Workflow* UI is activated rather than sending a PostMessage. Note that the :term:`WorkflowUrl`
+        property will be ignored completely if the WorkflowPostMessage property is set to ``true``.
+
+        If neither the :term:`WorkflowUrl` nor the :term:`WorkflowPostMessage` properties are set, the *Workflow*
+        UI will be hidden in |wac|.
+
+        ..  important::
+            This value will be ignored if :term:`WorkflowType` is not provided.
+
 
 .. _viewer customization:
 

--- a/docs/online/src/scenarios/postmessage.rst
+++ b/docs/online/src/scenarios/postmessage.rst
@@ -249,6 +249,7 @@ The host page receives the following messages; all others are ignored:
 * :data:`UI_Close`
 * :data:`UI_Edit`
 * :data:`UI_Sharing`
+* :data:`UI_Workflow`
 
 
 ..  _outgoing postmessage common values:
@@ -439,6 +440,36 @@ every outgoing PostMessage:
             "MessageId": "UI_Sharing",
             "SendTime": 1329014075000,
             "Values": {
+                "wdUserSession": "3692f636-2add-4b64-8180-42e9411c4984",
+                "ui-language": "en-us"
+            }
+        }
+
+..  data:: UI_Workflow
+
+    The UI_Workflow message is posted when the user activates the *Workflow* UI in Office Online. The host should use
+    this message to trigger any custom workflow UI.
+
+    To send this message, the :term:`WorkflowPostMessage` property in the :ref:`CheckFileInfo` response from the
+    host must be set to ``true``. Otherwise Office Online will not send this message.
+
+    ..  attribute:: Values
+        :noindex:
+
+        WorkflowType *(string)*
+            The :term:`WorkflowType` associated with the message. This will match one of the values provided by the
+            host in the :term:`WorkflowType` property in :ref:`CheckFileInfo`.
+
+
+    ..  rubric:: Example Message:
+
+    ..  code-block:: JSON
+
+        {
+            "MessageId": "UI_Workflow",
+            "SendTime": 1329014075000,
+            "Values": {
+                "WorkflowType": "Submit",
                 "wdUserSession": "3692f636-2add-4b64-8180-42e9411c4984",
                 "ui-language": "en-us"
             }

--- a/docs/online/src/scenarios/workflow.rst
+++ b/docs/online/src/scenarios/workflow.rst
@@ -1,9 +1,60 @@
 
 ..  _workflow:
 
-|stub-icon| Using workflow processes with |wac|
-===============================================
+Integrating |wac| with document workflow processes
+==================================================
 
-..  include:: ../../../_shared/stub.rst
+..  include:: ../../../_shared/prerelease.rst
 
-.. |issue| issue:: 258
+Hosts can integrate |wac| into workflow processes, so that users can use UI directly in |wac| to manage documents in
+a workflow.
+
+For example, consider a host that caters to customers in the education field. The host may provide a way for students
+to submit documents as part of an assignment. With the |wac| workflow features, hosts can configure |wac| to display
+a :guilabel:`Submit` button directly in the |wac| UI that, when activated, will display host-specific UI allowing the
+student to submit the document.
+
+
+Supporting workflows in |wac|
+-----------------------------
+
+In |wac|, documents participating in workflows display a button that takes the place of the :guilabel:`Share`
+button. The button's text is specific to the :term:`WorkflowType`.
+
+======================  ==========================
+:term:`WorkflowType`    |wac| workflow button text
+======================  ==========================
+Assign                  Manage Assignment
+Submit                  Submit
+======================  ==========================
+
+..  important::
+
+    In |wac|, the *Assign* and *Submit* workflow types are mutually exclusive. Only one of the two workflow
+    types should be set for a given document session.
+
+Much like :guilabel:`Share`, when clicked, the workflow button can either navigate to a URL in a new tab or post a
+message to the host frame.
+
+To navigate to a URL, set the :term:`WorkflowUrl` property to the URL that |wac| should navigate to.
+
+To post a message to the host frame instead, set the :term:`WorkflowPostMessage` property to ``true``. When clicked,
+|wac| will send the :js:data:`UI_Workflow` message to the host frame. The message includes the type of workflow that
+the document is participating in.
+
+..  tip::
+
+    |wac| will always save the latest copy of the document to the host when the workflow UI is activated. This
+    ensures that the host always has the latest copy of the document in order to use it in the workflow.
+
+
+Important considerations
+------------------------
+
+WOPI clients, including |wac|, do not understand what the workflow is and how it behaves. In other words, when you use
+the :term:`WorkflowUrl` or :term:`WorkflowPostMessage` properties, |wac| will display the workflow button and behave
+appropriately when triggered. However, if, for example, you wish to prevent a user from submitting the same document
+multiple times, you must handle that in your own UI. In other words, |wac| and other WOPI clients do not know
+anything about the workflow process except that the document is participating in a workflow so that the appropriate
+UI can be displayed. This provides the WOPI host great flexibility in their workflows, but the host is also
+responsible for managing the workflow as a whole.

--- a/docs/online/src/scenarios/workflow.rst
+++ b/docs/online/src/scenarios/workflow.rst
@@ -1,0 +1,9 @@
+
+..  _workflow:
+
+|stub-icon| Using workflow processes with |wac|
+===============================================
+
+..  include:: ../../../_shared/stub.rst
+
+.. |issue| issue:: 258

--- a/docs/online/src/scenarios/workflow.rst
+++ b/docs/online/src/scenarios/workflow.rst
@@ -33,8 +33,8 @@ Submit                  Submit
     In |wac|, the *Assign* and *Submit* workflow types are mutually exclusive. Only one of the two workflow
     types should be set for a given document session.
 
-Much like :guilabel:`Share`, when clicked, the workflow button can either navigate to a URL in a new tab or post a
-message to the host frame.
+Much like :guilabel:`Share`, when clicked, the workflow button can either navigate to a URL in a new browser tab/window
+or send a message to the host frame.
 
 To navigate to a URL, set the :term:`WorkflowUrl` property to the URL that |wac| should navigate to.
 

--- a/docs/online/src/scenarios/workflow.rst
+++ b/docs/online/src/scenarios/workflow.rst
@@ -34,7 +34,7 @@ Submit                  Submit
     types should be set for a given document session.
 
 Much like :guilabel:`Share`, when clicked, the workflow button can either navigate to a URL in a new browser tab/window
-or send a message to the host frame.
+or send a message to the :term:`host frame`.
 
 To navigate to a URL, set the :term:`WorkflowUrl` property to the URL that |wac| should navigate to.
 

--- a/docs/rest/src/_fragments/param_types.rst
+++ b/docs/rest/src/_fragments/param_types.rst
@@ -7,6 +7,7 @@ Type           Default value
 Boolean        ``false``
 String         The empty string
 Integer/Long   Varies; see individual properties for details
+Array          Empty array
 ============   ================
 
 ..  important::

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -603,9 +603,10 @@ Workflow properties
             exclusive depending on the WOPI client. WOPI clients must use the following guidelines when handling
             values in the WorkflowType array:
 
-            * If multiple values are provided and the WOPI client does not support multiple values, the client must use
-              the first supported value provided in the array.
             * If no supported values are provided, the WOPI client must behave as though the WorkflowType property was
+              not provided.
+            * If multiple values are provided and the WOPI client does not support multiple values, the client may
+              use the first supported value provided in the array or behave as though the WorkflowType property was
               not provided.
 
     WorkflowUrl

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -576,6 +576,47 @@ because they are pending deprecation or they are designated for future features 
         blog.
 
 
+Workflow properties
+~~~~~~~~~~~~~~~~~~~
+..  include:: ../../../_shared/prerelease.rst
+
+..  glossary::
+    :sorted:
+
+    WorkflowType
+        |prerelease|
+
+        An **array of strings** containing the workflow types available for the document. Possible values are:
+
+        * ``Assign``
+        * ``Submit``
+
+        This property must always be specified if :term:`WorkflowUrl` or :term:`WorkflowPostMessage` are provided. If
+        this property is *not* supplied, then both :term:`WorkflowUrl` and :term:`WorkflowPostMessage` must be ignored
+        by the WOPI client.
+
+        Conversely, if the WorkflowType property is provided but neither :term:`WorkflowUrl` nor
+        :term:`WorkflowPostMessage` are provided, then the WorkflowType value must be ignored by the WOPI client.
+
+        ..  important::
+            While this property is an array of strings, note that specific values of WorkflowType may be mutually
+            exclusive depending on the WOPI client. WOPI clients must use the following guidelines when handling
+            values in the WorkflowType array:
+
+            * If multiple values are provided and the WOPI client does not support multiple values, the client must use
+              the first supported value provided in the array.
+            * If no supported values are provided, the WOPI client must behave as though the WorkflowType property was
+              not provided.
+
+    WorkflowUrl
+        |prerelease|
+
+        A URI to a location that allows the user to participate in a workflow for the file.
+
+        ..  important::
+            This value will be ignored if :term:`WorkflowType` is not provided.
+
+
 Deprecated properties
 ---------------------
 


### PR DESCRIPTION
This is an initial attempt at adding info on the Workflow-related properties and post messages to the docs.

See #258, which tracks adding more narrative documentation around the workflow-related scenarios.