### PR TITLE
Adding documentation for Sharing

### DIFF
--- a/docs/rest/src/concepts.rst
+++ b/docs/rest/src/concepts.rst
@@ -168,6 +168,16 @@ understanding the requirements for integration with WOPI clients such as |wac| a
             :term:`SupportsExtendedLockLength` property in :ref:`CheckFileInfo`.
 
 
+    Share URL
+        A Share URL is a URL to a webpage that is suitable for viewing a shared WOPI file or container. The URL should be
+        appropriate for being launched in a web browser, but the experience is defined by the host. For example, 
+        the host may choose to have the URL navigate to the host's browse experience or to a preview of the file 
+        using Office Online or another file previewer. 
+
+        A host may support different types of Share URLs that may be used for different purposes. For example, a
+        particular Share URL type may not allow users to edit the file by using the Share URL. The list of possible
+        types are defined under the :term:`SupportedShareUrlTypes` property.
+
     WOPISrc
         The WOPISrc (*WOPI Source*) is the URL used to execute WOPI operations on a file. It is a combination of the
         :ref:`Files endpoint` URL for the host along with a particular :term:`file ID`. The WOPISrc does *not*

--- a/docs/rest/src/containers/CheckContainerInfo.rst
+++ b/docs/rest/src/containers/CheckContainerInfo.rst
@@ -63,6 +63,22 @@ LicenseCheckForEditIsEnabled
         A URI to a webpage to allow the user to control sharing of the container. This is analogous to the
         :term:`FileSharingUrl` in :ref:`CheckFileInfo`.
 
+    SupportedShareUrlTypes
+        An **array** of strings containing the :term:`Share URL` types supported by the host. The types
+        indicate the sharing options available for the container itself and not on the files in the container.
+
+        These types can be passed in the **X-WOPI-UrlType** request header to signify which Share URL type
+        to return for the :ref:`GetShareUrl (containers)` operation. 
+
+        Possible Values:
+
+        ReadOnly
+            This type of Share URL allows users to view the container using the URL, but does not give them
+            permission to make changes to the container. 
+
+        ReadWrite
+            This type of Share URL allows users to both view and make changes to the container using the URL.
+
     UserCanCreateChildContainer
         A **Boolean** value that indicates the user has permission to create a new container in the container.
 

--- a/docs/rest/src/containers/GetShareUrl.rst
+++ b/docs/rest/src/containers/GetShareUrl.rst
@@ -1,0 +1,54 @@
+
+..  index:: WOPI requests; GetShareUrl (containers), GetShareUrl (containers)
+
+..  |operation| replace:: GetShareUrl
+
+..  _GetShareUrl (containers):
+
+GetShareUrl (containers)
+==============================
+
+:Required for: |ios|
+
+..  seealso::
+
+    :ref:`GetShareUrl (files)`
+
+..  default-domain:: http
+
+..  post:: /wopi/containers/(container_id)
+
+    The |operation| operation returns a :term:`Share URL` that is suitable for viewing a shared container when launched 
+    in a web browser. A host can support multiple Share URL types, as described by the :term:`SupportedShareUrlTypes`
+    property. The **X-WOPI-UrlType** request header contains the Share URL type that should be returned. 
+
+    If the **X-WOPI-UrlType** header is not present or contains a value that is invalid or not supported by the host,
+    the host should respond with a :http:statuscode:`501`. 
+
+    ..  include:: /_fragments/common_containers_params.rst
+
+    :reqheader X-WOPI-Override:
+        The **string** ``GET_SHARE_URL``. Required.
+
+    :reqheader X-WOPI-UrlType:
+        A **string** indicating what Share URL type to return. Required.
+
+    :code 200: Success
+    :code 401: Invalid :term:`access token`
+    :code 404: Resource not found/user unauthorized
+    :code 500: Server error
+    :code 501: Operation not supported
+
+    ..  include:: /_fragments/common_headers.rst
+
+Response
+--------
+
+..  include:: /_fragments/json_response_required.rst
+
+ShareUrl
+    A URI that points to a webpage that allows the user to access the container. Required.
+
+    ..  seealso::
+
+        :term:`Share Url`

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -119,6 +119,21 @@ WOPI implementation meets the requirements for a particular property.
 ..  glossary::
     :sorted:
 
+    SupportedShareUrlTypes
+        An **array** of strings containing the :term:`Share URL` types supported by the host.
+
+        These types can be passed in the **X-WOPI-UrlType** request header to signify which Share URL type
+        to return for the :ref:`GetShareUrl (files)` operation.
+
+        Possible Values:
+
+        ReadOnly
+            This type of Share URL allows users to view the file using the URL, but does not give them
+            permission to edit the file. 
+
+        ReadWrite
+            This type of Share URL allows users to both view and edit the file using the URL.
+
     SupportsCobalt
         A **Boolean** value that indicates that the host supports the following WOPI
         operations:

--- a/docs/rest/src/files/GetShareUrl.rst
+++ b/docs/rest/src/files/GetShareUrl.rst
@@ -1,0 +1,55 @@
+
+..  index:: WOPI requests; GetShareUrl (files), GetShareUrl (files)
+
+..  |operation| replace:: GetShareUrl
+
+..  _GetShareUrl (files):
+..  _GetShareUrl:
+
+GetShareUrl (files)
+==============================
+
+:Required for: |ios|
+
+..  seealso::
+
+    :ref:`GetShareUrl (containers)`
+
+..  default-domain:: http
+
+..  post:: /wopi/files/(file_id)
+
+    The |operation| operation returns a :term:`Share URL` that is suitable for viewing a shared file when launched
+    in a web browser. A host can support multiple Share URL types, as described by the :term:`SupportedShareUrlTypes`
+    property. The **X-WOPI-UrlType** request header contains the Share URL type that should be returned. 
+
+    If the **X-WOPI-UrlType** header is not present or contains a value that is invalid or not supported by the host,
+    the host should respond with a :http:statuscode:`501`. 
+
+    ..  include:: /_fragments/common_params.rst
+
+    :reqheader X-WOPI-Override:
+        The **string** ``GET_SHARE_URL``. Required.
+
+    :reqheader X-WOPI-UrlType:
+        A **string** indicating what Share URL type to return. Required.
+
+    :code 200: Success
+    :code 401: Invalid :term:`access token`
+    :code 404: Resource not found/user unauthorized
+    :code 500: Server error
+    :code 501: Operation not supported
+
+    ..  include:: /_fragments/common_headers.rst
+
+Response
+--------
+
+..  include:: /_fragments/json_response_required.rst
+
+ShareUrl
+    A URI that points to a webpage that allows the user to access the file. Required.
+
+    ..  seealso::
+
+        :term:`Share Url`

--- a/docs/rest/src/index.rst
+++ b/docs/rest/src/index.rst
@@ -71,6 +71,7 @@ server intends to integrate with. To learn more about the specific requirements 
     /files/RenameFile
     /files/DeleteFile
     /files/EnumerateAncestors
+    /files/GetShareUrl
     /files/PutUserInfo
 
 
@@ -86,6 +87,7 @@ server intends to integrate with. To learn more about the specific requirements 
     /containers/DeleteContainer
     /containers/EnumerateAncestors
     /containers/EnumerateChildren
+    /containers/GetShareUrl
     /containers/RenameContainer
 
 


### PR DESCRIPTION
- We're extending the Wopi protocol to support Share URLs.
- I've updated the Key Concepts page with "Share URL" as a new term.
- I've updated CheckFileInfo and CheckContainerInfo with a new property
called SupportedShareUrlTypes.
- I've added two new pages for the GetShareUrl operation for files and
containers.