### PR TITLE
Add documentation for CheckFileInfoResponse.AllowErrorReportPrompt

### DIFF
--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -455,7 +455,7 @@ Other miscellaneous properties
         user for permission to collect a detailed report about their specific error.  The information gathered
         could include the user's file, and other session specific state.
 
-        ..  versionadded:: 2017.06.15
+        ..  versionadded:: 2017.06.01
         
         ..  tip::
             This value should be set to ``false`` if no additional collection should be done on errors, or if the

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -456,7 +456,7 @@ Other miscellaneous properties
         could include the user's file, and other session specific state.
 
         ..  versionadded:: 2017.06.01
-        
+
         ..  tip::
             This value should be set to ``false`` if no additional collection should be done on errors, or if the
             user has opted out of telemetry collection.

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -450,6 +450,17 @@ Other miscellaneous properties
         .. _Bing Spell Check API: https://www.microsoft.com/cognitive-services/en-us/bing-spell-check-api
         .. _Smart Lookup: https://support.office.microsoft.com/article/Get-insights-into-what-you-re-working-on-with-Smart-Lookup-debf2083-5ac0-4739-8667-ae2467bec044
 
+    AllowErrorReportPrompt
+        A **Boolean** value that indicates that if the session ends in an error, it is permitted to prompt the
+        user for permission to collect a detailed report about their specific error.  The information gathered
+        could include the user's file, and other session specific state.
+
+        ..  versionadded:: 2017.06.15
+        
+        ..  tip::
+            This value should be set to ``false`` if no additional collection should be done on errors, or if the
+            user has opted out of telemetry collection.
+
     AllowExternalMarketplace
         A **Boolean** value that indicates a WOPI client may allow connections to external services referenced in
         the file (for example, a marketplace of embeddable JavaScript apps).


### PR DESCRIPTION
Add documentation for the new AllowErrorRequestPrompt field on the CheckFileInfoResponse.

When set to true, if a user hits a failure, they can be prompted for additional information.

When set to false, no additional information is collected and no prompt is shown.