### PR TITLE
Make the FileVersion and PutUserInfo test groups required for prod

### DIFF
--- a/docs/online/src/_fragments/required_validator_tests.rst
+++ b/docs/online/src/_fragments/required_validator_tests.rst
@@ -9,6 +9,8 @@
 * PutRelativeFile **or** PutRelativeFileUnsupported
 * RenameFileIfCreateChildFileIsNotSupported **or** RenameFileIfCreateChildFileIsSupported (applicable only if the
   host supports :ref:`RenameFile`)
+* FileVersion
+* PutUserInfo (applicable only if the host supports :ref:`PutUserInfo`)
 * ProofKeys (applicable only for hosts implementing :ref:`proof key validation<proof keys>`)
 
 ..  tip::


### PR DESCRIPTION
The FileVersion tests are easy to address for hosts (add a header to the response for several WOPI operations) and reduce the amount of manual testing that needs to be done during validation.

The PutUserInfo tests are new; hosts that support PutUserInfo must be passing these tests to ensure their implementation is correct.