### PR TITLE
Fix sample wopi handler to pass all WopiCore Validation tests

### DIFF
--- a/samples/SampleWopiHandler/SampleWopiHandler/WopiHandler.cs
+++ b/samples/SampleWopiHandler/SampleWopiHandler/WopiHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Web;
@@ -240,7 +240,6 @@ namespace SampleWopiHandler
                 // An unknown request.
                 requestData.Type = RequestType.None;
             }
-
             return requestData;
         }
 
@@ -285,12 +284,15 @@ namespace SampleWopiHandler
                     BaseFileName = Path.GetFileName(requestData.FullPath),
                     OwnerId = "documentOwnerId",
                     Size = (int)fileInfo.Length,
+                    UserId = "user@contoso.com",
                     Version = fileInfo.LastWriteTimeUtc.ToString("O" /* ISO 8601 DateTime format string */), // Using the file write time is an arbitrary choice.
 
                     // optional CheckFileInfo properties
                     BreadcrumbBrandName = "LocalStorage WOPI Host",
                     BreadcrumbFolderName = fileInfo.Directory != null ? fileInfo.Directory.Name : "",
                     BreadcrumbDocName = Path.GetFileNameWithoutExtension(requestData.FullPath),
+                    BreadcrumbBrandUrl = "http://" + context.Request.Url.Host,
+                    BreadcrumbFolderUrl = "http://" + context.Request.Url.Host,
 
                     UserFriendlyName = "A WOPI User",
 
@@ -338,6 +340,7 @@ namespace SampleWopiHandler
             {
                 // transmit file from local storage to the response stream.
                 context.Response.TransmitFile(requestData.FullPath);
+                context.Response.AddHeader(WopiHeaders.ItemVersion, GetFileVersion(requestData.FullPath));
                 ReturnSuccess(context.Response);
             }
             catch (UnauthorizedAccessException)
@@ -348,6 +351,12 @@ namespace SampleWopiHandler
             {
                 ReturnFileUnknown(context.Response);
             }
+        }
+
+        private static string GetFileVersion(string filename)
+        {
+            FileInfo fileInfo = new FileInfo(filename);
+            return fileInfo.LastWriteTimeUtc.ToString("O" /* ISO 8601 DateTime format string */); // Using the file write time is an arbitrary choice.
         }
 
         /// <summary>
@@ -407,6 +416,7 @@ namespace SampleWopiHandler
                 {
                     context.Request.InputStream.CopyTo(fileStream);
                 }
+                context.Response.AddHeader(WopiHeaders.ItemVersion, GetFileVersion(requestData.FullPath));
             }
             catch (UnauthorizedAccessException)
             {
@@ -444,12 +454,10 @@ namespace SampleWopiHandler
             lock (Locks)
             {
                 LockInfo existingLock;
-                if (TryGetLock(requestData.Id, out existingLock))
+                bool fLocked = TryGetLock(requestData.Id, out existingLock);
+                if (fLocked && existingLock.Lock != newLock)
                 {
-                    // There is a valid existing lock on the file
-
-                    // Regardless of whether the new lock matches the existing lock, this should be treated as a lock mismatch
-                    // per the documentation: https://wopi.readthedocs.io/projects/wopirest/en/latest/files/Lock.html
+                    // There is a valid existing lock on the file and it doesn't match the requested lockstring.
 
                     // This is a fairly common case and shouldn't be tracked as an error.  Office Online can store
                     // information about a current session in the lock value and expects to conflict when there's
@@ -460,9 +468,14 @@ namespace SampleWopiHandler
                 {
                     // The file is not currently locked or the lock has already expired
 
+                    if (fLocked)
+                        Locks.Remove(requestData.Id);
+
                     // Create and store new lock information
                     // TODO: In a real implementation the lock should be stored in a persisted and shared system.
                     Locks[requestData.Id] = new LockInfo() { DateCreated = DateTime.UtcNow, Lock = newLock };
+
+                    context.Response.AddHeader(WopiHeaders.ItemVersion, GetFileVersion(requestData.FullPath));
 
                     // Return success
                     ReturnSuccess(context.Response);
@@ -555,6 +568,7 @@ namespace SampleWopiHandler
 
                         // Remove the current lock
                         Locks.Remove(requestData.Id);
+                        context.Response.AddHeader(WopiHeaders.ItemVersion, GetFileVersion(requestData.FullPath));
                         ReturnSuccess(context.Response);
                     }
                     else
@@ -655,7 +669,8 @@ namespace SampleWopiHandler
             // TODO: Access token validation is not implemented in this sample.
             // For more details on access tokens, see the documentation
             // https://wopi.readthedocs.io/projects/wopirest/en/latest/concepts.html#term-access-token
-            return !String.IsNullOrWhiteSpace(requestData.AccessToken);
+            // "INVALID" is used by the WOPIValidator.
+            return !String.IsNullOrWhiteSpace(requestData.AccessToken) && (requestData.AccessToken != "INVALID");
         }
 
         private static void ReturnSuccess(HttpResponse response)

--- a/samples/SampleWopiHandler/SampleWopiHandler/WopiRequest.cs
+++ b/samples/SampleWopiHandler/SampleWopiHandler/WopiRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace SampleWopiHandler
 {
@@ -32,6 +32,7 @@ namespace SampleWopiHandler
     static class WopiHeaders
     {
         public const string RequestType = "X-WOPI-Override";
+        public const string ItemVersion = "X-WOPI-ItemVersion";
 
         public const string Lock = "X-WOPI-Lock";
         public const string OldLock = "X-WOPI-OldLock";

--- a/samples/SampleWopiHandler/SampleWopiHandler/WopiResponse.cs
+++ b/samples/SampleWopiHandler/SampleWopiHandler/WopiResponse.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace SampleWopiHandler
 {
     class CheckFileInfoResponse
@@ -6,9 +6,11 @@ namespace SampleWopiHandler
         // This is a subset of all CheckFileInfo properties.
         // Use optional properties in accordance with the [MS-WOPI] Web Application Open Platform Interface Protocol specification.
 
+        // Required response properties
         public string BaseFileName { get; set; }
         public string OwnerId { get; set; }
         public int Size { get; set; }
+        public string UserId { get; set; }
         public string Version { get; set; }
 
         public string BreadcrumbBrandName { get; set; }
@@ -16,7 +18,6 @@ namespace SampleWopiHandler
         public string BreadcrumbFolderName { get; set; }
         public string BreadcrumbFolderUrl { get; set; }
         public string BreadcrumbDocName { get; set; }
-        public string BreadcrumbDocUrl { get; set; }
 
         public bool UserCanWrite { get; set; }
         public bool ReadOnly { get; set; }


### PR DESCRIPTION
AccessToken, FileVersion, DoubleLock and CheckFileInfoSchema test groups were failing for WopiCore. 