### PR TITLE
Add CobaltCapabilities to CheckFileInfo

### DIFF
--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -645,12 +645,14 @@ because they are pending deprecation or they are designated for future features 
             :term:`UserCanWrite` property for that purpose.
     
     CobaltCapabilities
-        A **array** of strings that contains the Cobalt capabilities supported by the host.
+        A **array of strings** that contains the Cobalt capabilities supported by the host. If :term:`SupportsCobalt` 
+        is set to ``false``, this property must be ignored by the WOPI client. Any value other than the possible values 
+        listed below must be ignored by the WOPI client.
 
         Possible Values:
 
         DownloadStreaming
-            This type of CobaltCapabilities indicates the host supports cobalt streaming for download 
+            This type of CobaltCapabilities indicates the host supports Cobalt streaming for download 
             at the moment it handles the request.
 
 

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -643,6 +643,14 @@ because they are pending deprecation or they are designated for future features 
         ..  note::
             This does not mean that the user doesn't have rights to edit the file. Hosts should use the
             :term:`UserCanWrite` property for that purpose.
+    
+    CobaltCapabilities
+        A **array** of strings that contains the Cobalt capabilities supported by the host.
+
+        Possible Values:
+
+        DownloadStreaming
+            This type of CobaltCapabilities indicates the host supports cobalt streaming for download at the moment it handles the request.
 
 
 Workflow properties

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -650,7 +650,8 @@ because they are pending deprecation or they are designated for future features 
         Possible Values:
 
         DownloadStreaming
-            This type of CobaltCapabilities indicates the host supports cobalt streaming for download at the moment it handles the request.
+            This type of CobaltCapabilities indicates the host supports cobalt streaming for download 
+            at the moment it handles the request.
 
 
 Workflow properties


### PR DESCRIPTION
An array of strings named CobaltCapabilities can be returned in the response of CheckFileInfo. Add this to the document