### PR TITLE
Add SharingStatus Documentation

### DIFF
--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -591,6 +591,19 @@ Other miscellaneous properties
         ..  admonition:: |wac| Tip
 
             See :ref:`View performance` for more details on how this property is used in |wac|.
+			
+    SharingStatus
+        |prerelease|
+
+        A **string** value indicating whether the current document is shared with other users. The value can change upon adding or removing permissions to other users.
+
+        Possible Values:
+
+        Private
+            Only the document owner has permission to the file.
+
+        Shared
+            At least one other user has access to the file via direct permissions or a sharing link.
 
     UniqueContentId
         |need_permission|

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -591,11 +591,13 @@ Other miscellaneous properties
         ..  admonition:: |wac| Tip
 
             See :ref:`View performance` for more details on how this property is used in |wac|.
-			
+
     SharingStatus
         |prerelease|
 
-        A **string** value indicating whether the current document is shared with other users. The value can change upon adding or removing permissions to other users.
+        A **string** value indicating whether the current document is shared with other users. The value can change
+        upon adding or removing permissions to other users. Clients should use this value to help decide when to enable
+        collaboration features as a document must be Shared in order to multi-user collaboration on the document. 
 
         Possible Values:
 
@@ -604,6 +606,9 @@ Other miscellaneous properties
 
         Shared
             At least one other user has access to the file via direct permissions or a sharing link.
+
+        If no value is specified, or an invalid value is provided, the default behavior is to assume the WOPI host intended the value
+        of None.
 
     UniqueContentId
         |need_permission|


### PR DESCRIPTION
Add SharingStatus Documentation for the new property being added to CheckFileInfo. SharingStatus is a new property that will allow you to understand if users other than the document owner have access to the file. 