### PR TITLE
Fix CSPP link in WOPI documentation.

### DIFF
--- a/docs/native/src/index.rst
+++ b/docs/native/src/index.rst
@@ -18,7 +18,7 @@ To integrate your application with |Office iOS Android|, you need to do the foll
 
 #. Be a member of the |cspp|. Currently integration with |Office iOS Android| using WOPI
    is available to cloud storage partners. You can learn more about the program, as well as how to apply, at
-   http://dev.office.com/programs/officecloudstorage.
+   https://developer.microsoft.com/office/cloud-storage-partner-program.
 
 #. Implement the WOPI protocol - a set of REST endpoints that expose information about the documents that you want to
    view or edit in |Office iOS Android|. The set of WOPI operations that must be supported is described

--- a/docs/native/src/overview.rst
+++ b/docs/native/src/overview.rst
@@ -46,7 +46,7 @@ application. The WOPI protocol enables |Office iOS Android| to access and change
 To integrate your application with |Office iOS Android|, you need to do the following:
 
 #.  Become a member of the |cspp|. You can learn more about the program, as well
-    as how to apply, at `|cspp|. <http://dev.office.com/programs/officecloudstorage>`_
+    as how to apply, at `|cspp|. <https://developer.microsoft.com/office/cloud-storage-partner-program>`_
 #.  Provide the required on-boarding information as described in the section titled :ref:`onboarding`.
 #.  Obtain your ProviderId and app store URLs from Microsoft. The app store URLs are the URLs you should use to
     launch Office on a platform's app store.
@@ -97,4 +97,4 @@ integration is as secure as possible, ensure that:
 Interested?
 -----------
 If you're interested in integrating your solution with |Office iOS Android|, take a moment to register at
-`Office 365 Cloud Storage Partner Program. <http://dev.office.com/programs/officecloudstorage>`_
+`Office 365 Cloud Storage Partner Program. <https://developer.microsoft.com/office/cloud-storage-partner-program>`_

--- a/docs/online/src/index.rst
+++ b/docs/online/src/index.rst
@@ -18,7 +18,7 @@ To integrate your application with |wac|, you need to do the following:
 
 #. Be a member of the |cspp|. Currently integration with the |wac| cloud service is available to cloud storage
    partners. You can learn more about the program, as well as how to apply, at
-   http://dev.office.com/programs/officecloudstorage.
+   https://developer.microsoft.com/office/cloud-storage-partner-program.
 
    ..  include:: /_fragments/intended_isv.rst
 

--- a/docs/online/src/overview.rst
+++ b/docs/online/src/overview.rst
@@ -135,4 +135,4 @@ Interested?
 -----------
 
 If you're interested in integrating your solution with |wac|, take a moment to register at
-`Office 365 Cloud Storage Partner Program <http://dev.office.com/programs/officecloudstorage>`_.
+`Office 365 Cloud Storage Partner Program <https://developer.microsoft.com/office/cloud-storage-partner-program>`_.


### PR DESCRIPTION
The Cloud Storage Partner Program links in the WOPI documentation have not been updated to their new location at Microsoft.com, and still point to their legacy location on Office.com.