### PR TITLE
Update information on the onboarding page

### DIFF
--- a/docs/_shared/rst_prolog.rst
+++ b/docs/_shared/rst_prolog.rst
@@ -8,7 +8,11 @@
 
 ..  Global links
 
+..  _cspp: https://developer.microsoft.com/office/cloud-storage-partner-program
+
 ..  _FIPS 180-2: http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
+
+..  _YammerGroup: https://www.yammer.com/officeenterprisenda/#/threads/inGroup?type=in_group&feedId=7197423
 
 ..  |need_permission| replace::
     :html:`<span class="tag label label-warning"><i class="fa fa-lock"></i> Not supported in the CSPP</span>`
@@ -40,6 +44,8 @@
 ..  |word-web| replace:: Word for the web
 
 ..  |visio-web| replace:: Visio for the web
+
+..  |YammerGroup| replace:: CSPP Yammer Group
 
 
 

--- a/docs/native/src/onboarding/onboarding.rst
+++ b/docs/native/src/onboarding/onboarding.rst
@@ -4,7 +4,13 @@
 Onboarding information
 ======================
 
-The following information must be supplied to Microsoft to enable end-to-end testing and release of
+The following information must be supplied to Microsoft to enable end-to-end testing and release of Office for iOS
+integration. After initially onboarding to the `Cloud Storage Partner Program
+<https://developer.microsoft.com/office/cloud-storage-partner-program>`_ (CSPP), you should be given access to
+the `CSPP Yammer Group
+<https://www.yammer.com/officeenterprisenda/#/threads/inGroup?type=in_group&feedId=7197423>`_. You can work with the
+onboarding representatives in that group to provide this information to Microsoft.
+
 |Office iOS| integration.
 
 +----------------+-------------+--------------------------------------------+--------------------------------------------------+

--- a/docs/native/src/onboarding/onboarding.rst
+++ b/docs/native/src/onboarding/onboarding.rst
@@ -5,11 +5,9 @@ Onboarding information
 ======================
 
 The following information must be supplied to Microsoft to enable end-to-end testing and release of
-|Office iOS| integration. After initially onboarding to the `Cloud Storage Partner Program
-<https://developer.microsoft.com/office/cloud-storage-partner-program>`_ (CSPP), you should be given
-access to the `CSPP Yammer Group
-<https://www.yammer.com/officeenterprisenda/#/threads/inGroup?type=in_group&feedId=7197423>`_. You
-can work with the onboarding representatives in that group to provide this information to Microsoft.
+|Office iOS| integration. After initially onboarding to the |cspp|_, you should be given
+access to the |YammerGroup|_. You
+can work with the onboarding representatives there to provide this information to Microsoft.
 
 +----------------+-------------+--------------------------------------------+--------------------------------------------------+
 | Property       | Data Type   | Sample Value                               | Description                                      |

--- a/docs/native/src/onboarding/onboarding.rst
+++ b/docs/native/src/onboarding/onboarding.rst
@@ -4,14 +4,12 @@
 Onboarding information
 ======================
 
-The following information must be supplied to Microsoft to enable end-to-end testing and release of Office for iOS
-integration. After initially onboarding to the `Cloud Storage Partner Program
-<https://developer.microsoft.com/office/cloud-storage-partner-program>`_ (CSPP), you should be given access to
-the `CSPP Yammer Group
-<https://www.yammer.com/officeenterprisenda/#/threads/inGroup?type=in_group&feedId=7197423>`_. You can work with the
-onboarding representatives in that group to provide this information to Microsoft.
-
-|Office iOS| integration.
+The following information must be supplied to Microsoft to enable end-to-end testing and release of
+|Office iOS| integration. After initially onboarding to the `Cloud Storage Partner Program
+<https://developer.microsoft.com/office/cloud-storage-partner-program>`_ (CSPP), you should be given
+access to the `CSPP Yammer Group
+<https://www.yammer.com/officeenterprisenda/#/threads/inGroup?type=in_group&feedId=7197423>`_. You
+can work with the onboarding representatives in that group to provide this information to Microsoft.
 
 +----------------+-------------+--------------------------------------------+--------------------------------------------------+
 | Property       | Data Type   | Sample Value                               | Description                                      |

--- a/docs/native/src/onboarding/onboarding.rst
+++ b/docs/native/src/onboarding/onboarding.rst
@@ -5,9 +5,9 @@ Onboarding information
 ======================
 
 The following information must be supplied to Microsoft to enable end-to-end testing and release of
-|Office iOS| integration. After initially onboarding to the |cspp|_, you should be given
-access to the |YammerGroup|_. You
-can work with the onboarding representatives there to provide this information to Microsoft.
+|Office iOS| integration. After initially onboarding to the |cspp|_, you should be given access to
+the |YammerGroup|_. You can work with the onboarding representatives there to provide this information
+to Microsoft.
 
 +----------------+-------------+--------------------------------------------+--------------------------------------------------+
 | Property       | Data Type   | Sample Value                               | Description                                      |


### PR DESCRIPTION
Add link to the CSPP Yammer Group in the onboarding page, so that folks know where they can go to provide the needed information to Microsoft.