### PR TITLE
Clarify the X-WOPI-Lock header concept

### DIFF
--- a/docs/rest/src/concepts.rst
+++ b/docs/rest/src/concepts.rst
@@ -127,12 +127,13 @@ understanding the requirements for integration with WOPI clients such as |wac| a
         * *Not* be associated with a particular user.
 
         All WOPI operations that modify files, such as :ref:`PutFile`, will include a lock ID as a parameter in their
-        request. Usually the ID will be passed in the **X-WOPI-Lock** request header (but not always;
-        :ref:`UnlockAndRelock` is an exception). WOPI requires that hosts compare the lock ID passed in a WOPI
-        request with the lock ID currently on a file and respond appropriately when the lock IDs do not match. In
-        particular, WOPI clients expect that when a lock ID does *not* match the current lock, the host will send
-        back the current lock ID in the **X-WOPI-Lock** response header. This behavior is critical, because WOPI
-        clients will use the current lock ID in order to determine what further WOPI calls to make to the host.
+        request. Usually the expected lock ID will be passed in the **X-WOPI-Lock** request header (but not always;
+        :ref:`UnlockAndRelock` is an exception which uses **X-WOPI-OldLock** instead). WOPI requires that hosts
+        compare the lock ID passed in a WOPI request with the lock ID currently on a file and respond appropriately
+        when the lock IDs do not match. In particular, WOPI clients expect that when a lock ID does *not* match the
+        current lock, the host will send back the current lock ID in the **X-WOPI-Lock** response header. This
+        behavior is critical, because WOPI clients will use the current lock ID in order to determine what further
+        WOPI calls to make to the host.
 
         It is important to note that WOPI locks are *not* user-owned. In other words, a WOPI client may execute
         lock-related operations using multiple access tokens, and hosts are expected to execute those operations as

--- a/docs/rest/src/files/CheckFileInfo.rst
+++ b/docs/rest/src/files/CheckFileInfo.rst
@@ -470,7 +470,6 @@ Other miscellaneous properties
             ..  seealso:: :ref:`avoid CloseButtonClosesWindow`
 
     ClientThrottlingProtection
-        |prerelease|
 
         A **string** value offering guidance to the WOPI client as to how to differentiate client throttling behaviors between the
         user and documents combinations from the WOPI host. Under times of stress, the WOPI client may choose to make use of this
@@ -554,7 +553,6 @@ Other miscellaneous properties
         example, ``"2009-06-15T13:45:30.0000000Z"``.
 
     RequestedCallThrottling
-        |prerelease|
 
         A **string** value indicating whether the WOPI host is experiencing capacity problems and would like to
         reduce the frequency at which the WOPI clients make calls to the host.  Each WOPI application may choose


### PR DESCRIPTION
We received feedback that the X-WOPI-Lock header concept is slightly confusing, particularly around the UnlockAndRelock exception.  The X-WOPI-Lock header on the unlock and relock request is the replacement lock not the expected lock.  Clarify the concept a little to help with this ambiguity.